### PR TITLE
Add copy and cut buttons for mobile selection

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -28,6 +28,7 @@ import {
   DownloadCloud,
   Square,
   Copy,
+  Scissors,
   ClipboardPaste,
   FileJson,
   FolderOpen,
@@ -176,23 +177,30 @@ const collect3mfMeshGroups = (group, layerOrder, advisorLayers) => {
     const target = meshGroups.get(layerKey);
     const indexAttribute = child.geometry.getIndex();
     const position = new THREE.Vector3();
-    const triangleBuffer = [];
+    const vertexOffset = target.vertices.length;
 
-    const pushVertex = (vertexIndex) => {
-      position.fromBufferAttribute(positionAttribute, vertexIndex);
+    for (let i = 0; i < positionAttribute.count; i++) {
+      position.fromBufferAttribute(positionAttribute, i);
       position.applyMatrix4(child.matrixWorld);
       target.vertices.push([position.x, position.y, position.z]);
-      triangleBuffer.push(target.vertices.length - 1);
-      if (triangleBuffer.length === 3) {
-        target.triangles.push([...triangleBuffer]);
-        triangleBuffer.length = 0;
-      }
-    };
+    }
 
     if (indexAttribute) {
-      for (let i = 0; i < indexAttribute.count; i++) pushVertex(indexAttribute.getX(i));
+      for (let i = 0; i < indexAttribute.count; i += 3) {
+        target.triangles.push([
+          vertexOffset + indexAttribute.getX(i),
+          vertexOffset + indexAttribute.getX(i + 1),
+          vertexOffset + indexAttribute.getX(i + 2),
+        ]);
+      }
     } else {
-      for (let i = 0; i < positionAttribute.count; i++) pushVertex(i);
+      for (let i = 0; i < positionAttribute.count; i += 3) {
+        target.triangles.push([
+          vertexOffset + i,
+          vertexOffset + i + 1,
+          vertexOffset + i + 2,
+        ]);
+      }
     }
   });
 
@@ -265,7 +273,30 @@ const build3mfMixMetadata = (advisorResult, meshGroups) => JSON.stringify({
     })),
 }, null, 2);
 
-const BambuFilamentSlotTokens = ['4', '8', '0C', '1C', '2C', '3C', '4C', '5C', '6C', '7C', '9C', 'AC', 'BC', 'CC', 'DC', 'EC', 'FC'];
+const buildAdvisorMixMetadata = (advisorResult) => JSON.stringify({
+  version: 1,
+  exportedAt: new Date().toISOString(),
+  baseColors: advisorResult.baseColors.map((rgb, index) => ({
+    index: index + 1,
+    hex: rgbToHex(rgb),
+    rgb,
+  })),
+  layers: advisorResult.layers.map((layer) => ({
+    layerKey: layer.key,
+    label: `Layer ${layer.layerNumber}`,
+    targetRgb: layer.targetRgb,
+    mixedRgb: layer.mixedRgb,
+    mixedHex: rgbToHex(layer.mixedRgb),
+    recipeLabel: layer.recipeLabel,
+    recipeComponents: layer.recipeComponents || [],
+    error: layer.error,
+    usageCount: layer.usageCount,
+  })),
+}, null, 2);
+
+const BambuFilamentSlotTokens = ['4', '8', '0C', '1C', '2C', '3C', '4C', '5C', '6C', '7C', '', 'AC', 'BC', 'CC', 'DC', 'EC', 'FC'];
+const MAX_OBSERVED_BAMBU_SLOT_COUNT = 11;
+const MAX_OBSERVED_BAMBU_MIXED_SLOT_COUNT = MAX_OBSERVED_BAMBU_SLOT_COUNT - COLOR_MIX_BASE_COUNT;
 
 const getBambuSlotToken = (slotNumber) => {
   if (slotNumber <= 0) return '4';
@@ -324,10 +355,37 @@ const isExperimentalBambuRecipe = (recipeComponents = []) => (
   recipeComponents.length > 2
 );
 
+const sortRecipeComponents = (components = []) => [...components]
+  .map(({ index, ratio }) => ({ index, ratio: Number(ratio || 0) }))
+  .sort((left, right) => left.index - right.index);
+
+const buildComponentsFromPaletteEntry = (entry) => {
+  if (!entry?.components?.length) return [];
+  return entry.components.map((component, componentIndex) => ({
+    index: component - 1,
+    ratio: Number(entry.ratios?.[componentIndex] || 0),
+  }));
+};
+
+const OBSERVED_BAMBU_TWO_COLOR_RATIO_TEMPLATES = [
+  [0.1, 0.9],
+  [0.2, 0.8],
+  [0.3, 0.7],
+  [0.5, 0.5],
+  [0.7, 0.3],
+  [0.8, 0.2],
+  [0.9, 0.1],
+];
+
+const OBSERVED_BAMBU_THREE_COLOR_RATIO_TEMPLATES = [
+  [0.28, 0.32, 0.4],
+];
+
 const buildBambuFilamentPalette = (advisorResult) => {
   const baseEntries = advisorResult.baseColors.map((rgb, index) => ({
     key: `root:${index}`,
     kind: 'root',
+    compatibilityKind: 'Root',
     slotNumber: index + 1,
     slotLabel: `Root ${index + 1}`,
     displayRgb: rgb,
@@ -337,71 +395,236 @@ const buildBambuFilamentPalette = (advisorResult) => {
     recipeLabel: `Base ${index + 1} 100%`,
     filamentIndex: index + 1,
     token: getBambuSlotToken(index + 1),
+    isBaseDerived: index === 0,
   }));
 
   const mixedEntryMap = new Map();
   advisorResult.layers.forEach((layer) => {
     if (!layer.recipeComponents?.length || layer.recipeComponents.length <= 1) return;
-    const recipeKey = layer.recipeComponents
-      .map(({ index, ratio }) => `${index + 1}:${formatBambuRatio(ratio)}`)
-      .join('|');
+    const recipeKey = buildBambuRecipeKey(layer.recipeComponents);
     if (mixedEntryMap.has(recipeKey)) return;
-    const supportedHalfMix = isSupportedBambuHalfMix(layer.recipeComponents);
+    const normalizedComponents = sortRecipeComponents(layer.recipeComponents);
     mixedEntryMap.set(recipeKey, {
       key: recipeKey,
       kind: 'mixed',
       displayRgb: layer.mixedRgb,
       displayHex: rgbToHex(layer.mixedRgb),
-      components: layer.recipeComponents.map(({ index }) => index + 1),
-      ratios: layer.recipeComponents.map(({ ratio }) => formatBambuRatio(ratio)),
-      isExperimental: !supportedHalfMix,
+      components: normalizedComponents.map(({ index }) => index + 1),
+      ratios: normalizedComponents.map(({ ratio }) => formatBambuRatio(ratio)),
+      isExperimental: !isObservedBambuRecipe(normalizedComponents),
     });
   });
 
   const mixedEntries = Array.from(mixedEntryMap.values())
     .sort((left, right) => (
-      getBambuRecipePriority(
-        left.components.map((component, componentIndex) => ({
-          index: component - 1,
-          ratio: Number(left.ratios[componentIndex] || 0),
-        })),
-      ) - getBambuRecipePriority(
-        right.components.map((component, componentIndex) => ({
-          index: component - 1,
-          ratio: Number(right.ratios[componentIndex] || 0),
-        })),
-      )
+      getBambuRecipePriority(buildComponentsFromPaletteEntry(left))
+      - getBambuRecipePriority(buildComponentsFromPaletteEntry(right))
       || left.components.length - right.components.length
       || left.components.join(',').localeCompare(right.components.join(','))
       || left.ratios.join(',').localeCompare(right.ratios.join(','))
     ))
+    .slice(0, MAX_OBSERVED_BAMBU_MIXED_SLOT_COUNT)
     .map((entry, index) => ({
-    ...entry,
-    slotNumber: baseEntries.length + index + 1,
-    slotLabel: `Root ${baseEntries.length + index + 1}`,
-    recipeLabel: formatMixRecipe(entry.components.map(({ index: componentIndex, ratio }) => ({ index: componentIndex, ratio: Number(ratio) }))),
-    filamentIndex: baseEntries.length + index + 1,
-    token: getBambuSlotToken(baseEntries.length + index + 1),
-  }));
+      ...entry,
+      slotNumber: baseEntries.length + index + 1,
+      slotLabel: `Root ${baseEntries.length + index + 1}`,
+      recipeLabel: formatMixRecipe(buildComponentsFromPaletteEntry(entry)),
+      compatibilityKind: entry.components.length === 2 ? '2-color mix' : '3-color mix',
+      filamentIndex: baseEntries.length + index + 1,
+      token: getBambuSlotToken(baseEntries.length + index + 1),
+    }));
 
   const byLayerKey = new Map();
+  const selectableEntries = [...baseEntries, ...mixedEntries];
   advisorResult.layers.forEach((layer) => {
     if (!layer.recipeComponents?.length || layer.recipeComponents.length === 1) {
       const componentIndex = layer.recipeComponents?.[0]?.index ?? 0;
       byLayerKey.set(layer.key, baseEntries[componentIndex] || baseEntries[0]);
       return;
     }
-    const recipeKey = layer.recipeComponents
-      .map(({ index, ratio }) => `${index + 1}:${formatBambuRatio(ratio)}`)
-      .join('|');
-    byLayerKey.set(layer.key, mixedEntryMap.has(recipeKey)
-      ? mixedEntries.find((entry) => entry.key === recipeKey)
-      : baseEntries[0]);
+    const recipeKey = buildBambuRecipeKey(layer.recipeComponents);
+    const exactEntry = mixedEntries.find((entry) => entry.key === recipeKey);
+    if (exactEntry) {
+      byLayerKey.set(layer.key, exactEntry);
+      return;
+    }
+
+    const targetOklab = rgbToOklab(layer.mixedRgb || layer.targetRgb);
+    let bestEntry = baseEntries[0];
+    let bestError = Number.POSITIVE_INFINITY;
+    selectableEntries.forEach((entry) => {
+      const candidateError = getOklabDistance(targetOklab, rgbToOklab(entry.displayRgb));
+      if (
+        candidateError < bestError - 0.0001
+        || (
+          Math.abs(candidateError - bestError) <= 0.0001
+          && getBambuRecipePriority(buildComponentsFromPaletteEntry(entry)) < getBambuRecipePriority(buildComponentsFromPaletteEntry(bestEntry))
+        )
+      ) {
+        bestError = candidateError;
+        bestEntry = entry;
+      }
+    });
+    byLayerKey.set(layer.key, bestEntry);
   });
 
   return {
     entries: [...baseEntries, ...mixedEntries],
     byLayerKey,
+  };
+};
+
+const getBambuPixelWorldBounds = (x, y, width, height, dotSize, topZ, bottomZ = 0) => {
+  const left = (x - width / 2) * dotSize;
+  const right = left + dotSize;
+  const top = (height / 2 - y) * dotSize;
+  const bottom = top - dotSize;
+  return {
+    left,
+    right,
+    top,
+    bottom,
+    topZ,
+    bottomZ,
+    centerX: left + dotSize / 2,
+    centerY: bottom + dotSize / 2,
+    centerZ: bottomZ + (topZ - bottomZ) / 2,
+  };
+};
+
+const buildBambuPaintMeshData = (pixels, dotSize, totalThickness, advisorResult, filamentPalette) => {
+  if (!pixels || !advisorResult || !filamentPalette) return null;
+  const height = pixels.length;
+  const width = pixels[0]?.length || 0;
+  if (!width || !height) return null;
+
+  const advisorLayerMap = new Map(advisorResult.layers.map((layer) => [layer.key, layer]));
+  const baseEntry = filamentPalette.entries[0];
+  const vertexMap = new Map();
+  const vertices = [];
+  const triangles = [];
+  const previewInstances = new Map();
+
+  const addVertex = (x, y, z) => {
+    const key = `${x.toFixed(5)}|${y.toFixed(5)}|${z.toFixed(5)}`;
+    if (vertexMap.has(key)) return vertexMap.get(key);
+    const index = vertices.length;
+    vertices.push([x, y, z]);
+    vertexMap.set(key, index);
+    return index;
+  };
+
+  const pushFace = (points, paintColor, previewKey, previewDisplayRgb) => {
+    const indices = points.map(([x, y, z]) => addVertex(x, y, z));
+    triangles.push({
+      v1: indices[0],
+      v2: indices[1],
+      v3: indices[2],
+      paintColor,
+      previewKey,
+      previewDisplayRgb,
+    });
+    triangles.push({
+      v1: indices[0],
+      v2: indices[2],
+      v3: indices[3],
+      paintColor,
+      previewKey,
+      previewDisplayRgb,
+    });
+  };
+
+  const isFilled = (x, y) => (
+    y >= 0
+    && y < height
+    && x >= 0
+    && x < width
+    && JSON.stringify(pixels[y][x]) !== TRANSPARENT_KEY
+  );
+
+  pixels.forEach((row, y) => row.forEach((pixel, x) => {
+    const layerKey = JSON.stringify(pixel);
+    if (layerKey === TRANSPARENT_KEY) return;
+    const advisorLayer = advisorLayerMap.get(layerKey);
+    const paletteEntry = filamentPalette.byLayerKey.get(layerKey) || baseEntry;
+    const token = paletteEntry?.token || baseEntry?.token || '4';
+    const displayRgb = advisorLayer?.mixedRgb || paletteEntry?.displayRgb || pixel;
+    if (!previewInstances.has(token)) {
+      previewInstances.set(token, {
+        token,
+        slotNumber: paletteEntry?.slotNumber || 1,
+        displayRgb,
+        positions: [],
+      });
+    }
+
+    const bounds = getBambuPixelWorldBounds(x, y, width, height, dotSize, totalThickness, 0);
+    previewInstances.get(token).positions.push([
+      bounds.centerX,
+      bounds.centerY,
+      bounds.centerZ,
+    ]);
+
+    const baseToken = baseEntry?.token || token;
+    const previewKey = `slot:${paletteEntry?.slotNumber || 1}`;
+    const basePreviewKey = `slot:${baseEntry?.slotNumber || 1}`;
+    const {
+      left, right, top, bottom, topZ, bottomZ,
+    } = bounds;
+
+    pushFace([
+      [left, top, topZ],
+      [left, bottom, topZ],
+      [right, bottom, topZ],
+      [right, top, topZ],
+    ], token, previewKey, displayRgb);
+
+    pushFace([
+      [left, top, bottomZ],
+      [right, top, bottomZ],
+      [right, bottom, bottomZ],
+      [left, bottom, bottomZ],
+    ], baseToken, basePreviewKey, baseEntry?.displayRgb || displayRgb);
+
+    if (!isFilled(x, y - 1)) {
+      pushFace([
+        [left, top, bottomZ],
+        [left, top, topZ],
+        [right, top, topZ],
+        [right, top, bottomZ],
+      ], baseToken, basePreviewKey, baseEntry?.displayRgb || displayRgb);
+    }
+    if (!isFilled(x, y + 1)) {
+      pushFace([
+        [left, bottom, bottomZ],
+        [right, bottom, bottomZ],
+        [right, bottom, topZ],
+        [left, bottom, topZ],
+      ], baseToken, basePreviewKey, baseEntry?.displayRgb || displayRgb);
+    }
+    if (!isFilled(x - 1, y)) {
+      pushFace([
+        [left, bottom, bottomZ],
+        [left, bottom, topZ],
+        [left, top, topZ],
+        [left, top, bottomZ],
+      ], baseToken, basePreviewKey, baseEntry?.displayRgb || displayRgb);
+    }
+    if (!isFilled(x + 1, y)) {
+      pushFace([
+        [right, bottom, bottomZ],
+        [right, top, bottomZ],
+        [right, top, topZ],
+        [right, bottom, topZ],
+      ], baseToken, basePreviewKey, baseEntry?.displayRgb || displayRgb);
+    }
+  }));
+
+  return {
+    vertices,
+    triangles,
+    faceCount: triangles.length,
+    previewInstances: Array.from(previewInstances.values()).sort((left, right) => left.slotNumber - right.slotNumber),
   };
 };
 
@@ -411,40 +634,11 @@ const generatePseudoUuid = (seed) => {
   return `${normalized}-81cb-4c03-9d28-${suffix}`;
 };
 
-const collectBambuMeshGroups = (group, layerOrder, advisorLayers, filamentPalette) => (
-  collect3mfMeshGroups(group, layerOrder, advisorLayers).map((meshGroup, index) => {
-    const paletteEntry = filamentPalette.byLayerKey.get(meshGroup.layerKey) || filamentPalette.entries[0];
-    return {
-      ...meshGroup,
-      objectId: index + 1,
-      bambuPaintToken: paletteEntry?.token || '8',
-      bambuFilamentIndex: paletteEntry?.filamentIndex || 1,
-      bambuPaletteEntry: paletteEntry || null,
-    };
-  })
-);
-
-const buildBambuGenericModelXml = (meshGroups, metadata) => {
-  const allVertices = [];
-  const allTriangles = [];
-
-  meshGroups.forEach((group) => {
-    const vertexOffset = allVertices.length;
-    group.vertices.forEach((vertex) => allVertices.push(vertex));
-    group.triangles.forEach(([v1, v2, v3]) => {
-      allTriangles.push({
-        v1: v1 + vertexOffset,
-        v2: v2 + vertexOffset,
-        v3: v3 + vertexOffset,
-        paintColor: group.bambuPaintToken,
-      });
-    });
-  });
-
-  const verticesXml = allVertices
+const buildBambuGenericModelXml = (meshData, metadata) => {
+  const verticesXml = meshData.vertices
     .map(([x, y, z]) => `<vertex x="${x}" y="${y}" z="${z}" />`)
     .join('');
-  const trianglesXml = allTriangles
+  const trianglesXml = meshData.triangles
     .map(({ v1, v2, v3, paintColor }) => `<triangle v1="${v1}" v2="${v2}" v3="${v3}" paint_color="${paintColor}" />`)
     .join('');
 
@@ -471,8 +665,8 @@ const buildBambuGenericModelXml = (meshGroups, metadata) => {
 </model>`;
 };
 
-const buildBambuGenericModelSettingsConfig = (meshGroups, metadata) => {
-  const totalFaceCount = meshGroups.reduce((sum, group) => sum + group.triangles.length, 0);
+const buildBambuGenericModelSettingsConfig = (meshData, metadata) => {
+  const totalFaceCount = meshData.faceCount;
   return `<?xml version="1.0" encoding="UTF-8"?>
 <config>
   <object id="1">
@@ -553,6 +747,7 @@ const buildBambuProjectSettingsConfig = (filamentPalette) => {
 const getBambuCompatibilityLabel = (recipeComponents = []) => {
   if (!recipeComponents.length || recipeComponents.length === 1) return 'Root';
   if (isSupportedBambuHalfMix(recipeComponents)) return '2-color mix';
+  if (recipeComponents.length === 3) return '3-color mix';
   return 'Experimental';
 };
 
@@ -584,15 +779,119 @@ const mixLinearRgb = (colors, weights) => {
 
 const formatRgbLabel = (rgb) => `RGB(${rgb[0]}, ${rgb[1]}, ${rgb[2]})`;
 
+const clampRgbChannel = (value) => Math.max(0, Math.min(255, Math.round(value)));
+
+const adjustRgbBrightness = (rgb, stepCount = 0) => {
+  if (!Array.isArray(rgb) || !stepCount) return rgb;
+  return rgb.map((channel) => {
+    let nextChannel = Number(channel || 0);
+    if (stepCount > 0) {
+      for (let index = 0; index < stepCount; index += 1) {
+        nextChannel += (255 - nextChannel) * 0.1;
+      }
+    } else {
+      for (let index = 0; index < Math.abs(stepCount); index += 1) {
+        nextChannel *= 0.9;
+      }
+    }
+    return clampRgbChannel(nextChannel);
+  });
+};
+
 const formatMixRecipe = (components) => components.map(({ index, ratio }) => `Base ${index + 1} ${Math.round(ratio * 100)}%`).join(' + ');
 
 const isRoot1BasedRecipe = (components = []) => components.some(({ index }) => index === 0);
+
+const buildBambuRecipeKey = (components = []) => sortRecipeComponents(components)
+  .map(({ index, ratio }) => `${index + 1}:${Number(ratio || 0).toFixed(4)}`)
+  .join('|');
+
+const OBSERVED_BAMBU_RECIPE_KEYS = new Set([
+  '1:0.1000|2:0.9000',
+  '1:0.3000|2:0.7000',
+  '1:0.5000|2:0.5000',
+  '1:0.7000|2:0.3000',
+  '1:0.8000|2:0.2000',
+  '1:0.9000|2:0.1000',
+  '1:0.7000|3:0.3000',
+  '2:0.2000|3:0.8000',
+  '2:0.5000|3:0.5000',
+  '2:0.7000|3:0.3000',
+  '2:0.8000|3:0.2000',
+  '3:0.5000|4:0.5000',
+  '2:0.2800|3:0.3200|4:0.4000',
+]);
+
+const isObservedBambuRecipe = (components = []) => {
+  if (!components.length) return false;
+  if (components.length === 1) return true;
+  return OBSERVED_BAMBU_RECIPE_KEYS.has(buildBambuRecipeKey(components));
+};
 
 const getBambuRecipePriority = (components = []) => {
   if (!components.length) return 100;
   const includesRoot1 = isRoot1BasedRecipe(components);
   if (components.length === 1) return includesRoot1 ? 0 : 10 + components[0].index;
   return includesRoot1 ? 20 : 40;
+};
+
+const applyBambuPaletteBrightnessAdjustments = (filamentPalette, adjustments = {}) => {
+  if (!filamentPalette) return null;
+  const keyToAdjustedEntry = new Map();
+  const adjustedEntries = filamentPalette.entries.map((entry) => {
+    const brightnessSteps = adjustments[entry.key] || 0;
+    const displayRgb = adjustRgbBrightness(entry.displayRgb, brightnessSteps);
+    const adjustedEntry = {
+      ...entry,
+      displayRgb,
+      displayHex: rgbToHex(displayRgb),
+      brightnessSteps,
+    };
+    keyToAdjustedEntry.set(entry.key, adjustedEntry);
+    return adjustedEntry;
+  });
+
+  const adjustedByLayerKey = new Map();
+  filamentPalette.byLayerKey.forEach((entry, layerKey) => {
+    adjustedByLayerKey.set(layerKey, keyToAdjustedEntry.get(entry.key) || entry);
+  });
+
+  return {
+    entries: adjustedEntries,
+    byLayerKey: adjustedByLayerKey,
+  };
+};
+
+const applyBambuPaletteToResult = (advisorResult, filamentPalette) => {
+  if (!advisorResult || !filamentPalette) return null;
+  const layers = advisorResult.layers.map((layer) => {
+    const paletteEntry = filamentPalette.byLayerKey.get(layer.key);
+    if (!paletteEntry) return layer;
+    const error = getOklabDistance(rgbToOklab(layer.targetRgb), rgbToOklab(paletteEntry.displayRgb));
+    const assignedComponents = buildComponentsFromPaletteEntry(paletteEntry);
+    return {
+      ...layer,
+      recipeLabel: paletteEntry.recipeLabel,
+      recipeComponents: assignedComponents.length ? assignedComponents : layer.recipeComponents,
+      mixedRgb: paletteEntry.displayRgb,
+      error,
+      compatibilityKind: paletteEntry.compatibilityKind || 'Root',
+      isBaseDerived: assignedComponents.length ? isRoot1BasedRecipe(assignedComponents) : true,
+      assignedSlot: paletteEntry.slotNumber,
+      paintToken: paletteEntry.token,
+    };
+  });
+  const errors = layers.map((layer) => layer.error);
+  return {
+    ...advisorResult,
+    layers,
+    summary: {
+      ...advisorResult.summary,
+      maxError: Math.max(...errors),
+      averageError: errors.reduce((sum, value) => sum + value, 0) / errors.length,
+      withinThresholdCount: layers.filter((layer) => layer.error <= COLOR_MIX_GOOD_MATCH_THRESHOLD).length,
+    },
+  };
 };
 
 const dedupeRgbList = (colors) => {
@@ -790,11 +1089,29 @@ const buildBambuCompatibleCandidates = (baseColors) => {
 
   for (let left = 0; left < baseColors.length; left += 1) {
     for (let right = left + 1; right < baseColors.length; right += 1) {
-      for (let step = 1; step < COLOR_MIX_RATIO_STEPS; step += 1) {
-        pushCandidate([
-          { index: left, ratio: step / COLOR_MIX_RATIO_STEPS },
-          { index: right, ratio: (COLOR_MIX_RATIO_STEPS - step) / COLOR_MIX_RATIO_STEPS },
-        ], '2-color mix');
+      OBSERVED_BAMBU_TWO_COLOR_RATIO_TEMPLATES.forEach(([leftRatio, rightRatio]) => {
+        const components = [
+          { index: left, ratio: leftRatio },
+          { index: right, ratio: rightRatio },
+        ];
+        if (!isObservedBambuRecipe(components)) return;
+        pushCandidate(components, '2-color mix');
+      });
+    }
+  }
+
+  for (let first = 0; first < baseColors.length; first += 1) {
+    for (let second = first + 1; second < baseColors.length; second += 1) {
+      for (let third = second + 1; third < baseColors.length; third += 1) {
+        OBSERVED_BAMBU_THREE_COLOR_RATIO_TEMPLATES.forEach(([firstRatio, secondRatio, thirdRatio]) => {
+          const components = [
+            { index: first, ratio: firstRatio },
+            { index: second, ratio: secondRatio },
+            { index: third, ratio: thirdRatio },
+          ];
+          if (!isObservedBambuRecipe(components)) return;
+          pushCandidate(components, '3-color mix');
+        });
       }
     }
   }
@@ -848,6 +1165,7 @@ const buildBambuCompatibilityResult = (pixels, layerOrder, baseColors) => {
       averageError: errors.reduce((sum, value) => sum + value, 0) / errors.length,
       rootCount: layers.filter((layer) => layer.compatibilityKind === 'Root').length,
       twoColorMixCount: layers.filter((layer) => layer.compatibilityKind === '2-color mix').length,
+      threeColorMixCount: layers.filter((layer) => layer.compatibilityKind === '3-color mix').length,
       baseDerivedCount: layers.filter((layer) => layer.isBaseDerived).length,
     },
   };
@@ -1498,12 +1816,14 @@ const App = () => {
   const [isExportingBambu3MF, setIsExportingBambu3MF] = useState(false);
   const [isExportingOBJ, setIsExportingOBJ] = useState(false);
   const [is3DExportMenuOpen, setIs3DExportMenuOpen] = useState(false);
+  const [threeViewMode, setThreeViewMode] = useState('stack');
   const [selected3DLayer, setSelected3DLayer] = useState(null);
   const [is3DLayerMoveMode, setIs3DLayerMoveMode] = useState(false);
   const [draft3DLayerOrder, setDraft3DLayerOrder] = useState([]);
   const [pendingLayerColors, setPendingLayerColors] = useState({});
   const [jumpHighlightedLayer, setJumpHighlightedLayer] = useState(null);
   const [canvasLayerJumpColor, setCanvasLayerJumpColor] = useState(null);
+  const [bambuSlotBrightnessAdjustments, setBambuSlotBrightnessAdjustments] = useState({});
   
   const handleLayerHeightChange = (colorStr, key, delta) => setLayerHeightAdjustments(prev => {
     const current = prev[colorStr] || { plus: 0, minus: 0 };
@@ -1621,11 +1941,16 @@ const App = () => {
   const bambuCompatibilityResult = pixels && hasValidRootColors
     ? buildBambuCompatibilityResult(pixels, layerOrder, parsedRootColors)
     : null;
-  const appliedRootColorResult = bambuCompatibilityResult;
-  const bambuFilamentPalette = appliedRootColorResult
-    ? buildBambuFilamentPalette(appliedRootColorResult)
+  const rawBambuFilamentPalette = bambuCompatibilityResult
+    ? buildBambuFilamentPalette(bambuCompatibilityResult)
     : null;
-  const is3mfExportReady = Boolean(pixels && rootColorPreviewResult);
+  const bambuFilamentPalette = rawBambuFilamentPalette
+    ? applyBambuPaletteBrightnessAdjustments(rawBambuFilamentPalette, bambuSlotBrightnessAdjustments)
+    : null;
+  const appliedRootColorResult = bambuCompatibilityResult && bambuFilamentPalette
+    ? applyBambuPaletteToResult(bambuCompatibilityResult, bambuFilamentPalette)
+    : null;
+  const is3mfExportReady = Boolean(pixels && appliedRootColorResult);
   const isBambuQuantized = Boolean(
     rootColorPreviewResult
     && bambuCompatibilityResult
@@ -1686,15 +2011,30 @@ const App = () => {
     if (!pixels) return;
     const suggestedColors = suggestIdealMixBaseColors(pixels, COLOR_MIX_BASE_COUNT);
     setCustomMixBaseHexes(Array.from({ length: COLOR_MIX_BASE_COUNT }, (_, index) => suggestedColors[index] ? rgbToHex(suggestedColors[index]) : ''));
+    setBambuSlotBrightnessAdjustments({});
     setStatusMessage(suggestedColors.length ? `Loaded ${suggestedColors.length} accent-aware root colors from the current model.` : 'No visible layer colors found.');
   }, [pixels]);
 
+  const adjustBambuSlotBrightness = useCallback((entryKey, delta) => {
+    setBambuSlotBrightnessAdjustments((prev) => {
+      const nextValue = Math.max(-5, Math.min(5, (prev[entryKey] || 0) + delta));
+      if (nextValue === 0) {
+        const { [entryKey]: _unused, ...rest } = prev;
+        return rest;
+      }
+      return {
+        ...prev,
+        [entryKey]: nextValue,
+      };
+    });
+  }, []);
+
   const updateRootColors = useCallback(() => {
-    if (!pixels || !bambuCompatibilityResult) {
+    if (!pixels || !appliedRootColorResult) {
       setStatusMessage('Please prepare 4 valid root colors first.');
       return;
     }
-    const appliedState = buildAppliedColorMixState(pixels, layerOrder, layerHeightAdjustments, layerSmoothingSettings, bambuCompatibilityResult);
+    const appliedState = buildAppliedColorMixState(pixels, layerOrder, layerHeightAdjustments, layerSmoothingSettings, appliedRootColorResult);
     if (!appliedState) {
       setStatusMessage('No root color update is available.');
       return;
@@ -1706,7 +2046,7 @@ const App = () => {
     setLayerSmoothingSettings(appliedState.nextLayerSmoothingSettings);
 
     const currentColorKey = JSON.stringify(currentColor);
-    const replacementLayer = bambuCompatibilityResult.layers.find((layer) => layer.key === currentColorKey);
+    const replacementLayer = appliedRootColorResult.layers.find((layer) => layer.key === currentColorKey);
     if (replacementLayer) setCurrentColor(replacementLayer.mixedRgb);
 
     pushToHistory(appliedState.nextPixels, {
@@ -1717,7 +2057,7 @@ const App = () => {
     setStatusMessage(isBambuQuantized
       ? 'Updated the model using Bambu-compatible root colors.'
       : 'Updated the model using the current root colors.');
-  }, [bambuCompatibilityResult, currentColor, isBambuQuantized, layerHeightAdjustments, layerOrder, layerSmoothingSettings, pixels, pushToHistory]);
+  }, [appliedRootColorResult, currentColor, isBambuQuantized, layerHeightAdjustments, layerOrder, layerSmoothingSettings, pixels, pushToHistory]);
 
   const handleLayerColorChange = useCallback((sourceKey, nextHex) => {
     if (!pixels) return;
@@ -2135,11 +2475,7 @@ const App = () => {
   }, [isExporting3MF, layerOrder, outputFileName, projectName, rootColorPreviewResult]);
 
   const exportBambu3MF = useCallback(async () => {
-    if (!sceneRef.current) {
-      setStatusMessage('No Bambu 3MF export source is available.');
-      return;
-    }
-    if (!rootColorPreviewResult) {
+    if (!appliedRootColorResult) {
       setStatusMessage('Please prepare 4 valid root colors before exporting Bambu 3MF.');
       return;
     }
@@ -2148,13 +2484,18 @@ const App = () => {
     setIsExportingBambu3MF(true);
     setStatusMessage('Bambu 3MFを構築中...');
     try {
-      if (!bambuCompatibilityResult) {
+      if (!appliedRootColorResult || !bambuFilamentPalette) {
         setStatusMessage('Bambu compatibility data is unavailable.');
         return;
       }
-      const filamentPalette = buildBambuFilamentPalette(bambuCompatibilityResult);
-      const meshGroups = collectBambuMeshGroups(sceneRef.current, layerOrder, bambuCompatibilityResult.layers, filamentPalette);
-      if (!meshGroups.length) {
+      const paintMeshData = buildBambuPaintMeshData(
+        pixels,
+        dotSize,
+        Math.max(0.2, baseThickness + layerThickness),
+        appliedRootColorResult,
+        bambuFilamentPalette,
+      );
+      if (!paintMeshData || !paintMeshData.vertices.length || !paintMeshData.triangles.length) {
         setStatusMessage('No mesh data available for Bambu 3MF export.');
         return;
       }
@@ -2167,10 +2508,10 @@ const App = () => {
         projectName: projectName || 'dotplate',
         sourceFileName,
       };
-      const topLevelModelXml = buildBambuGenericModelXml(meshGroups, metadata);
-      const modelSettingsConfig = buildBambuGenericModelSettingsConfig(meshGroups, metadata);
-      const projectSettingsConfig = buildBambuProjectSettingsConfig(filamentPalette);
-      const mixMetadataJson = build3mfMixMetadata(bambuCompatibilityResult, meshGroups);
+      const topLevelModelXml = buildBambuGenericModelXml(paintMeshData, metadata);
+      const modelSettingsConfig = buildBambuGenericModelSettingsConfig(paintMeshData, metadata);
+      const projectSettingsConfig = buildBambuProjectSettingsConfig(bambuFilamentPalette);
+      const mixMetadataJson = buildAdvisorMixMetadata(appliedRootColorResult);
       const zip = new JSZip();
       zip.file('[Content_Types].xml', `<?xml version="1.0" encoding="UTF-8"?>
 <Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">
@@ -2203,7 +2544,7 @@ const App = () => {
     } finally {
       setIsExportingBambu3MF(false);
     }
-  }, [bambuCompatibilityResult, isBambuQuantized, isExportingBambu3MF, layerOrder, outputFileName, projectName, rootColorPreviewResult]);
+  }, [appliedRootColorResult, bambuFilamentPalette, baseThickness, dotSize, isBambuQuantized, isExportingBambu3MF, layerThickness, outputFileName, pixels, projectName]);
 
   const exportImage = useCallback(async () => {
     if (!pixels || isExporting) return; setIsExporting(true); setStatusMessage("画像を構築中...");
@@ -2408,6 +2749,26 @@ const App = () => {
     setClipboard({ data: d, width: x2 - x1 + 1, height: y2 - y1 + 1 }); setSelection(null); setStatusMessage("コピーしました！"); setTool('paste');
   }, [selection]);
 
+  const handleCut = useCallback((e) => {
+    if (e) { e.preventDefault(); e.stopPropagation(); }
+    if (!selection || !pixelsRef.current) return;
+    const x1 = Math.min(selection.start.x, selection.end.x); const x2 = Math.max(selection.start.x, selection.end.x);
+    const y1 = Math.min(selection.start.y, selection.end.y); const y2 = Math.max(selection.start.y, selection.end.y);
+    const d = [];
+    const nextPixels = pixelsRef.current.map(row => row.map(pixel => [...pixel]));
+    for (let y = y1; y <= y2; y++) {
+      d.push(pixelsRef.current[y].slice(x1, x2 + 1));
+      for (let x = x1; x <= x2; x++) nextPixels[y][x] = [...TRANSPARENT_COLOR];
+    }
+    setClipboard({ data: d, width: x2 - x1 + 1, height: y2 - y1 + 1 });
+    setPixels(nextPixels);
+    syncLayersFromPixels(nextPixels);
+    pushToHistory(nextPixels);
+    setSelection(null);
+    setStatusMessage("切り取りました！");
+    setTool('paste');
+  }, [selection, pushToHistory, syncLayersFromPixels]);
+
   const applyLayerOrderChange = useCallback((nextLayerOrder, options = {}) => {
     if (!pixels) return false;
     if (nextLayerOrder.length !== layerOrder.length || nextLayerOrder.every((key, index) => key === layerOrder[index])) return false;
@@ -2464,6 +2825,12 @@ const App = () => {
     }
   }, [activeTab, is3DLayerMoveMode]);
 
+  useEffect(() => {
+    if (threeViewMode === 'bambu-paint' && is3DLayerMoveMode) {
+      cancel3DLayerMoveMode();
+    }
+  }, [cancel3DLayerMoveMode, is3DLayerMoveMode, threeViewMode]);
+
   const applyLayerSort = useCallback((mode) => {
     if (mode === 'current' || !pixels) return;
     const nextLayerOrder = getSortedLayerOrder(layerOrder, pixels, mode);
@@ -2505,12 +2872,12 @@ const App = () => {
       container.appendChild(renderer.domElement); const controls = new OrbitControls(camera, renderer.domElement);
       renderer.domElement.style.cursor = 'grab';
       scene.add(new THREE.AmbientLight(0xffffff, 0.6)); const light = new THREE.DirectionalLight(0xffffff, 0.8); light.position.set(200, 400, 200); scene.add(light);
-      const group = new THREE.Group(); const h = pixels.length; const w = pixels[0].length;
+      const stackGroup = new THREE.Group(); const h = pixels.length; const w = pixels[0].length;
       const raycaster = new THREE.Raycaster(); const pointer = new THREE.Vector2(); const selectableMeshes = [];
       if (baseThickness > 0) {
         const baseGeo = new THREE.BoxGeometry(w * dotSize, h * dotSize, baseThickness);
         const baseMesh = new THREE.Mesh(baseGeo, new THREE.MeshLambertMaterial({ color: 0xdddddd }));
-        baseMesh.position.set(0, 0, baseThickness / 2); group.add(baseMesh);
+        baseMesh.position.set(0, 0, baseThickness / 2); stackGroup.add(baseMesh);
       }
       let cz = baseThickness;
       displayLayerOrder.forEach((cs, li) => {
@@ -2554,12 +2921,60 @@ const App = () => {
               emissive: isSelectedLayer ? new THREE.Color(0xffffff) : new THREE.Color(0x000000),
               emissiveIntensity: isSelectedLayer ? 0.22 : 0,
             });
-            const mesh = new THREE.Mesh(geom, mat); mesh.position.z = cz - zMinus; mesh.userData.layerKey = cs; group.add(mesh); selectableMeshes.push(mesh);
+            const mesh = new THREE.Mesh(geom, mat); mesh.position.z = cz - zMinus; mesh.userData.layerKey = cs; stackGroup.add(mesh); selectableMeshes.push(mesh);
           });
         }
         cz += (layerThickness + zPlus);
       });
-      scene.add(group); sceneRef.current = group; const box = new THREE.Box3().setFromObject(group); const center = box.getCenter(new THREE.Vector3());
+      const bambuPreviewGroup = new THREE.Group();
+      if (bambuCompatibilityResult && bambuFilamentPalette) {
+        const previewData = buildBambuPaintMeshData(
+          pixels,
+          dotSize,
+          Math.max(0.2, baseThickness + layerThickness),
+          bambuCompatibilityResult,
+          bambuFilamentPalette,
+        );
+        if (previewData) {
+          const trianglesByPreviewKey = new Map();
+
+          previewData.triangles.forEach((triangle) => {
+            const previewKey = triangle.previewKey || triangle.paintColor;
+            if (!trianglesByPreviewKey.has(previewKey)) {
+              trianglesByPreviewKey.set(previewKey, []);
+            }
+            trianglesByPreviewKey.get(previewKey).push(triangle);
+          });
+
+          trianglesByPreviewKey.forEach((previewTriangles) => {
+            if (!previewTriangles.length) return;
+            const positions = new Float32Array(previewTriangles.length * 9);
+            previewTriangles.forEach(({ v1, v2, v3 }, triangleIndex) => {
+              const offset = triangleIndex * 9;
+              const vertex1 = previewData.vertices[v1];
+              const vertex2 = previewData.vertices[v2];
+              const vertex3 = previewData.vertices[v3];
+              positions.set(vertex1, offset);
+              positions.set(vertex2, offset + 3);
+              positions.set(vertex3, offset + 6);
+            });
+
+            const geometry = new THREE.BufferGeometry();
+            geometry.setAttribute('position', new THREE.BufferAttribute(positions, 3));
+            geometry.computeVertexNormals();
+
+            const displayRgb = previewTriangles[0]?.previewDisplayRgb || bambuFilamentPalette.entries[0]?.displayRgb || [220, 220, 220];
+            const material = new THREE.MeshLambertMaterial({
+              color: new THREE.Color(`rgb(${displayRgb[0]},${displayRgb[1]},${displayRgb[2]})`),
+              side: THREE.DoubleSide,
+            });
+            const mesh = new THREE.Mesh(geometry, material);
+            bambuPreviewGroup.add(mesh);
+          });
+        }
+      }
+      const visibleGroup = threeViewMode === 'bambu-paint' ? bambuPreviewGroup : stackGroup;
+      scene.add(visibleGroup); sceneRef.current = stackGroup; const box = new THREE.Box3().setFromObject(visibleGroup); const center = box.getCenter(new THREE.Vector3());
       if (threeCameraPositionRef.current && threeControlsTargetRef.current) {
         camera.position.copy(threeCameraPositionRef.current);
         controls.target.copy(threeControlsTargetRef.current);
@@ -2599,7 +3014,7 @@ const App = () => {
       const handleControlsEnd = () => { renderer.domElement.style.cursor = 'grab'; };
       controls.addEventListener('start', handleControlsStart);
       controls.addEventListener('end', handleControlsEnd);
-      if (is3DLayerMoveMode) {
+      if (is3DLayerMoveMode && threeViewMode === 'stack') {
         renderer.domElement.addEventListener('pointerdown', handlePointerDown);
         renderer.domElement.addEventListener('pointermove', handlePointerMove);
         renderer.domElement.addEventListener('pointerup', handlePointerUp);
@@ -2612,7 +3027,7 @@ const App = () => {
       };
       animate();
       return () => {
-        if (is3DLayerMoveMode) {
+        if (is3DLayerMoveMode && threeViewMode === 'stack') {
           renderer.domElement.removeEventListener('pointerdown', handlePointerDown);
           renderer.domElement.removeEventListener('pointermove', handlePointerMove);
           renderer.domElement.removeEventListener('pointerup', handlePointerUp);
@@ -2626,11 +3041,12 @@ const App = () => {
         while (container.firstChild) container.removeChild(container.firstChild);
       };
     }
-  }, [activeTab, pixels, dotSize, layerThickness, baseThickness, layerOrder, layerHeightAdjustments, layerSmoothingSettings, selected3DLayer, draft3DLayerOrder, is3DLayerMoveMode]);
+  }, [activeTab, pixels, dotSize, layerThickness, baseThickness, layerOrder, layerHeightAdjustments, layerSmoothingSettings, selected3DLayer, draft3DLayerOrder, is3DLayerMoveMode, threeViewMode, bambuCompatibilityResult, bambuFilamentPalette]);
 
   const selected3DLayerIndex = selected3DLayer ? (is3DLayerMoveMode ? draft3DLayerOrder.indexOf(selected3DLayer) : layerOrder.indexOf(selected3DLayer)) : -1;
   const selected3DLayerColor = selected3DLayerIndex >= 0 ? JSON.parse(selected3DLayer) : null;
   const canShowCanvasLayerJump = canvasLayerJumpColor && layerOrder.includes(JSON.stringify(canvasLayerJumpColor));
+  const canShowSelectionActions = tool === 'select' && !!selection && !!pixels;
 
   return (
     <div className="flex flex-col h-screen bg-slate-50 text-slate-900 font-sans select-none overflow-hidden relative text-left">
@@ -2784,7 +3200,12 @@ const App = () => {
                   {useVirtualPad && pixels && (
                     <div className="sticky inset-0 pointer-events-none z-30 h-full w-full">
                       <div className="absolute bottom-28 left-6 pointer-events-auto flex flex-col gap-3">
-                        {tool === 'select' && selection && (<button onPointerDown={handleCopy} className="w-12 h-12 rounded-xl bg-indigo-600 text-white flex items-center justify-center shadow-xl border-2 border-indigo-400 active:scale-90"><Copy size={18}/></button>)}
+                        {canShowSelectionActions && (
+                          <div className="flex flex-col gap-2">
+                            <button onClick={handleCopy} className="w-12 h-12 rounded-xl bg-indigo-600 text-white flex items-center justify-center shadow-xl border-2 border-indigo-400 active:scale-90"><Copy size={18}/></button>
+                            <button onClick={handleCut} className="w-12 h-12 rounded-xl bg-rose-600 text-white flex items-center justify-center shadow-xl border-2 border-rose-400 active:scale-90"><Scissors size={18}/></button>
+                          </div>
+                        )}
                         <button onPointerDown={startPlotting} onPointerUp={stopPlotting} className={`w-16 h-16 rounded-full flex items-center justify-center border-4 shadow-2xl transition-all ${isPlotting ? 'bg-indigo-600/80 border-indigo-400 text-white scale-95' : 'bg-white/40 backdrop-blur-sm border-white/50 text-indigo-600'}`}><span className="text-[10px] font-black uppercase tracking-widest">{tool === 'paste' ? 'Paste' : 'Plot'}</span></button>
                       </div>
                       <div className="absolute bottom-28 right-6 pointer-events-auto">
@@ -2797,6 +3218,18 @@ const App = () => {
                 </div>
                 {pixels && !useVirtualPad && (
                   <div className="absolute top-4 right-4 z-50 flex flex-col items-end gap-2">
+                    {canShowSelectionActions && (
+                      <div className="flex items-center gap-2">
+                        <button onClick={handleCopy} className="flex items-center justify-center gap-2 px-3 py-2 rounded-xl bg-indigo-600 text-white border border-indigo-400 shadow-lg active:scale-95 transition">
+                          <Copy size={16} />
+                          <span className="text-[9px] font-black uppercase tracking-widest">Copy</span>
+                        </button>
+                        <button onClick={handleCut} className="flex items-center justify-center gap-2 px-3 py-2 rounded-xl bg-rose-600 text-white border border-rose-400 shadow-lg active:scale-95 transition">
+                          <Scissors size={16} />
+                          <span className="text-[9px] font-black uppercase tracking-widest">Cut</span>
+                        </button>
+                      </div>
+                    )}
                     {canShowCanvasLayerJump && (
                       <button
                         onClick={handleCanvasLayerJump}
@@ -2952,13 +3385,40 @@ const App = () => {
               <div className="px-4 sm:px-6 py-3 border-b border-slate-50 flex flex-col gap-3 shrink-0">
                 <div className="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-3">
                   <div className="min-w-0">
-                    <h2 className="text-base font-black tracking-tight uppercase flex items-center gap-2 shrink-0"><BoxIcon className="text-indigo-600" size={18}/> 3D Preview</h2>
+                    <div className="flex flex-col gap-2">
+                      <h2 className="text-base font-black tracking-tight uppercase flex items-center gap-2 shrink-0"><BoxIcon className="text-indigo-600" size={18}/> 3D Preview</h2>
+                      <div className="flex flex-wrap items-center gap-2">
+                        <button
+                          onClick={() => setThreeViewMode('stack')}
+                          className={`px-3 py-1.5 rounded-full text-[9px] font-black uppercase tracking-widest transition ${
+                            threeViewMode === 'stack'
+                              ? 'bg-indigo-600 text-white shadow-lg'
+                              : 'bg-white text-slate-500 border border-slate-200 hover:border-indigo-300 hover:text-indigo-600'
+                          }`}
+                        >
+                          Layer Stack
+                        </button>
+                        <button
+                          onClick={() => setThreeViewMode('bambu-paint')}
+                          className={`px-3 py-1.5 rounded-full text-[9px] font-black uppercase tracking-widest transition ${
+                            threeViewMode === 'bambu-paint'
+                              ? 'bg-amber-500 text-white shadow-lg'
+                              : 'bg-white text-slate-500 border border-slate-200 hover:border-amber-300 hover:text-amber-600'
+                          }`}
+                        >
+                          Bambu Paint
+                        </button>
+                      </div>
+                    </div>
                     <div className="pt-2">
                       <p className={`text-[9px] font-black uppercase tracking-widest ${is3mfExportReady ? 'text-emerald-600' : 'text-amber-600'}`}>
                         {is3mfExportReady ? '3MF ready' : 'Needs re-evaluation for 3MF export'}
                       </p>
                       <p className={`text-[8px] font-bold uppercase tracking-widest mt-1 ${isBambuQuantized ? 'text-amber-500' : 'text-emerald-600'}`}>
                         {isBambuQuantized ? 'Bambu 3MF will quantize recipes to Root or 2-color mixes' : 'Bambu Compatible'}
+                      </p>
+                      <p className="text-[8px] font-bold uppercase tracking-widest mt-1 text-slate-400">
+                        {threeViewMode === 'bambu-paint' ? 'Viewing printable solid with painted top faces' : 'Viewing stacked layer geometry'}
                       </p>
                     </div>
                   </div>
@@ -2969,7 +3429,7 @@ const App = () => {
                         <button onClick={confirm3DLayerMoveMode} className="flex-1 sm:flex-none min-w-[112px] flex items-center justify-center gap-1 bg-indigo-600 text-white px-3 py-2 rounded-xl text-[9px] font-black shadow-lg hover:bg-indigo-700 transition active:scale-95">Confirm</button>
                       </>
                     ) : (
-                      <button onClick={enter3DLayerMoveMode} className="flex-1 sm:flex-none min-w-[132px] flex items-center justify-center gap-1 bg-white text-slate-600 px-3 py-2 rounded-xl text-[9px] font-black shadow-sm border border-slate-200 hover:border-indigo-300 hover:text-indigo-600 transition active:scale-95">Move Layers</button>
+                      <button onClick={enter3DLayerMoveMode} disabled={threeViewMode !== 'stack'} className="flex-1 sm:flex-none min-w-[132px] flex items-center justify-center gap-1 bg-white text-slate-600 px-3 py-2 rounded-xl text-[9px] font-black shadow-sm border border-slate-200 hover:border-indigo-300 hover:text-indigo-600 transition active:scale-95 disabled:opacity-40 disabled:cursor-not-allowed">Move Layers</button>
                     )}
                     <button onClick={exportSTL} className="flex-1 sm:flex-none min-w-[112px] flex items-center justify-center gap-2 bg-emerald-500 text-white px-4 py-2 rounded-xl text-[9px] font-black shadow-lg hover:bg-emerald-600 transition active:scale-95"><Download size={14} /> STL</button>
                     <div className="relative flex-1 sm:flex-none min-w-[56px]">
@@ -3106,7 +3566,7 @@ const App = () => {
                           <p className="text-[8px] font-black text-slate-400 uppercase tracking-widest">Preview After Update</p>
                           <p className="text-sm font-black text-slate-800">How the current layers will update for Bambu-compatible printing with these 4 root colors</p>
                           {isBambuQuantized && (
-                            <p className="mt-1 text-[9px] font-bold text-amber-600">Some colors were quantized to Root or 2-color mixes so the printed result matches the Bambu export.</p>
+                            <p className="mt-1 text-[9px] font-bold text-amber-600">Some colors were quantized to Root, 2-color mixes, or observed 3-color mixes so the printed result matches the Bambu export.</p>
                           )}
                         </div>
                         <div className="flex flex-wrap gap-2 items-center">
@@ -3127,7 +3587,7 @@ const App = () => {
                         <div className="rounded-xl border border-slate-100 bg-white px-3 py-2"><p className="text-[8px] font-black text-slate-400 uppercase tracking-widest">Avg Error</p><p className="text-sm font-black text-slate-800">{appliedRootColorResult.summary.averageError.toFixed(3)}</p></div>
                         <div className="rounded-xl border border-slate-100 bg-white px-3 py-2"><p className="text-[8px] font-black text-slate-400 uppercase tracking-widest">Within {COLOR_MIX_GOOD_MATCH_THRESHOLD.toFixed(2)}</p><p className="text-sm font-black text-slate-800">{appliedRootColorResult.summary.withinThresholdCount ?? appliedRootColorResult.summary.layerCount} / {appliedRootColorResult.summary.layerCount}</p></div>
                       </div>
-                      <div className="grid gap-2 sm:grid-cols-3">
+                      <div className="grid gap-2 sm:grid-cols-2 xl:grid-cols-4">
                         <div className="rounded-xl border border-slate-100 bg-white px-3 py-2">
                           <p className="text-[8px] font-black text-slate-400 uppercase tracking-widest">Root Layers</p>
                           <p className="text-sm font-black text-slate-800">{appliedRootColorResult.summary.rootCount}</p>
@@ -3135,6 +3595,10 @@ const App = () => {
                         <div className="rounded-xl border border-slate-100 bg-white px-3 py-2">
                           <p className="text-[8px] font-black text-slate-400 uppercase tracking-widest">2-Color Mix Layers</p>
                           <p className="text-sm font-black text-slate-800">{appliedRootColorResult.summary.twoColorMixCount}</p>
+                        </div>
+                        <div className="rounded-xl border border-slate-100 bg-white px-3 py-2">
+                          <p className="text-[8px] font-black text-slate-400 uppercase tracking-widest">3-Color Mix Layers</p>
+                          <p className="text-sm font-black text-slate-800">{appliedRootColorResult.summary.threeColorMixCount ?? 0}</p>
                         </div>
                         <div className="rounded-xl border border-slate-100 bg-white px-3 py-2">
                           <p className="text-[8px] font-black text-slate-400 uppercase tracking-widest">Bambu Avg Error</p>
@@ -3154,6 +3618,23 @@ const App = () => {
                                 <div className="flex-1 min-w-0">
                                   <p className="text-[8px] font-black text-slate-400 uppercase tracking-widest">{entry.slotLabel}{entry.slotNumber === 1 ? ' (Base)' : ''}</p>
                                   <p className="text-[9px] font-bold text-slate-700 truncate">{entry.recipeLabel}</p>
+                                  <p className="text-[8px] text-slate-400 font-black mt-1">{entry.brightnessSteps ? `${entry.brightnessSteps > 0 ? '+' : ''}${entry.brightnessSteps * 10}%` : '0%'}</p>
+                                </div>
+                                <div className="flex items-center gap-1 shrink-0">
+                                  <button
+                                    type="button"
+                                    onClick={() => adjustBambuSlotBrightness(entry.key, -1)}
+                                    className="w-7 h-7 rounded-lg border border-slate-200 bg-slate-50 text-slate-600 text-[10px] font-black hover:bg-slate-100 transition"
+                                  >
+                                    -10
+                                  </button>
+                                  <button
+                                    type="button"
+                                    onClick={() => adjustBambuSlotBrightness(entry.key, 1)}
+                                    className="w-7 h-7 rounded-lg border border-slate-200 bg-slate-50 text-slate-600 text-[10px] font-black hover:bg-slate-100 transition"
+                                  >
+                                    +10
+                                  </button>
                                 </div>
                                 <div className="text-right shrink-0">
                                   <p className="text-[8px] font-black text-slate-400 uppercase tracking-widest">Token</p>
@@ -3175,9 +3656,9 @@ const App = () => {
                                   <p className="text-[9px] font-bold text-slate-700">{rgbToHex(layer.targetRgb)}</p>
                                 </div>
                               </div>
-                              <div className="flex-1 min-w-[160px]">
-                                <p className="text-[8px] font-black text-slate-400 uppercase tracking-widest">Bambu Recipe</p>
-                                <p className="text-[9px] font-bold text-slate-700">{layer.recipeLabel}</p>
+                                <div className="flex-1 min-w-[160px]">
+                                  <p className="text-[8px] font-black text-slate-400 uppercase tracking-widest">Bambu Recipe</p>
+                                  <p className="text-[9px] font-bold text-slate-700">{layer.recipeLabel}</p>
                                 {'compatibilityKind' in layer && (
                                   <p className="mt-1 inline-flex rounded-full bg-indigo-50 text-indigo-600 px-2 py-0.5 text-[8px] font-black uppercase tracking-widest">
                                     {layer.compatibilityKind}
@@ -3190,10 +3671,11 @@ const App = () => {
                                 )}
                               </div>
                               {bambuFilamentPalette?.byLayerKey.get(layer.key) && (
-                                <div className="min-w-[108px]">
+                                <div className="min-w-[132px]">
                                   <p className="text-[8px] font-black text-slate-400 uppercase tracking-widest">Assigned Slot</p>
                                   <p className="text-[9px] font-black text-slate-700">{bambuFilamentPalette.byLayerKey.get(layer.key).slotLabel}</p>
-                                  <p className="text-[8px] text-indigo-600 font-black">Token {bambuFilamentPalette.byLayerKey.get(layer.key).token}</p>
+                                  <p className="text-[8px] text-indigo-600 font-black">Token {bambuFilamentPalette.byLayerKey.get(layer.key).token || '(empty)'}</p>
+                                  <p className="text-[8px] text-slate-400 font-black">Slot #{bambuFilamentPalette.byLayerKey.get(layer.key).slotNumber}</p>
                                 </div>
                               )}
                               <div className="flex items-center gap-2 min-w-[132px]">


### PR DESCRIPTION
## Summary
- show selection actions during regular canvas selection, not just on the virtual pad
- add a Cut action alongside Copy for selection workflows
- clear the selected rectangle to transparency after cutting and switch to paste mode

Closes #30